### PR TITLE
Remove Dialogs ; 

### DIFF
--- a/src/slic3r/GUI/DeviceManager.cpp
+++ b/src/slic3r/GUI/DeviceManager.cpp
@@ -2992,12 +2992,17 @@ int MachineObject::parse_json(std::string payload)
                             else if (jj["errno"].get<int>() == -4) {
                                  text = _L("When you set the chamber temperature below 40\u2103, the chamber temperature control will not be activated. And the target chamber temperature will automatically be set to 0\u2103.");
                             }
-                            if(!text.empty()){
-#if __WXOSX__
-                            set_ctt_dlg(text);
-#else
-                            GUI::wxGetApp().show_dialog(text);
-#endif
+                            //printago -- this wasn't working in windows for me (only recieve these in mac).
+                            //along w/ the refactor to remove dialog pops, we always call set_ctt_dlg, which in turn will flip the message out to all connected clients.
+//                             if(!text.empty()){
+// #if __WXOSX__
+//                             set_ctt_dlg(text);
+// #else
+//                             GUI::wxGetApp().show_dialog(text);
+// #endif
+//                             }
+                            if (!text.empty()) {
+                                set_ctt_dlg(text);
                             }
                         }
                     }

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -5326,9 +5326,13 @@ void GUI_App::update_internal_development() {
 
 void GUI_App::show_ip_address_enter_dialog(wxString title)
 {
-    auto evt = new wxCommandEvent(EVT_SHOW_IP_DIALOG);
-    evt->SetString(title);
-    wxQueueEvent(this, evt);
+    wxGetApp().CallAfter([ref = this] {
+        wxGetApp().printago_director()->PostDialogMessage("ShowIPAddress", "ShowIPAddress",
+                                                          "A print comms error occurred; Orca attempted to open an IP Dialog.");
+           });
+    // auto evt = new wxCommandEvent(EVT_SHOW_IP_DIALOG);
+    // evt->SetString(title);
+    // wxQueueEvent(this, evt);
 }
 
 bool GUI_App::show_modal_ip_address_enter_dialog(wxString title)

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2561,7 +2561,6 @@ bool GUI_App::on_init_inner()
             // }
             // });
 
-        //TODO: printago : comment out this event and return;
         Bind(EVT_ENTER_FORCE_UPGRADE, [this](const wxCommandEvent& evt) {
                 wxString      version_str = wxString::FromUTF8(this->app_config->get("upgrade", "version"));
                 wxString      description_text = wxString::FromUTF8(this->app_config->get("upgrade", "description"));

--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -2588,14 +2588,12 @@ bool GUI_App::on_init_inner()
                 }
             });
 
-        // TODO: printago : comment out this event and return;
         Bind(EVT_SHOW_NO_NEW_VERSION, [this](const wxCommandEvent& evt) {
             wxString msg = _L("This is the newest version.");
             InfoDialog dlg(nullptr, _L("Info"), msg);
             dlg.ShowModal();
         });
 
-        // TODO: printago : comment out this event and return;
         Bind(EVT_SHOW_DIALOG, [this](const wxCommandEvent& evt) {
             wxString msg = evt.GetString();
             InfoDialog dlg(this->mainframe, _L("Info"), msg);

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -71,7 +71,8 @@ MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &he
     apply_style(style);
 	SetSizerAndFit(main_sizer);
     wxGetApp().UpdateDlgDarkUI(this);
-    m_message = headline; //set here, and if if there's a further message in the derived class, it will be appended to this
+    m_style    = style;
+    m_headline = headline; 
 }
 
  MsgDialog::~MsgDialog()
@@ -337,7 +338,7 @@ ErrorDialog::ErrorDialog(wxWindow *parent, const wxString &msg, bool monospaced_
                         wxString::Format(_(L("%s has encountered an error")), SLIC3R_APP_FULL_NAME), wxOK)
 	, msg(msg)
 {
-    m_message += ": " +  msg;
+    m_message = msg;
     add_msg_content(this, content_sizer, msg, monospaced_font);
 
 	// Use a small bitmap with monospaced font, as the error text will not be wrapped.
@@ -357,7 +358,7 @@ WarningDialog::WarningDialog(wxWindow *parent,
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s warning"), SLIC3R_APP_FULL_NAME) : caption, 
                         wxString::Format(_L("%s has a warning")+":", SLIC3R_APP_FULL_NAME), style)
 {
-    m_message += ": " +  message;
+    m_message = message;
     add_msg_content(this, content_sizer, message);
     finalize();
 }
@@ -371,7 +372,7 @@ MessageDialog::MessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
-    m_message += ": " +  message;
+    m_message = message;
     add_msg_content(this, content_sizer, message);
     finalize();
     wxGetApp().UpdateDlgDarkUI(this);
@@ -386,7 +387,7 @@ RichMessageDialog::RichMessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
-    m_message += ": " +  message;
+    m_message = message;
     add_msg_content(this, content_sizer, message);
 
     m_checkBox = new wxCheckBox(this, wxID_ANY, m_checkBoxText);
@@ -416,7 +417,7 @@ InfoDialog::InfoDialog(wxWindow* parent, const wxString &title, const wxString& 
     : MsgDialog(parent, wxString::Format(_L("%s information"), SLIC3R_APP_FULL_NAME), title, style)
 	, msg(msg)
 {
-    m_message += ": " +  msg;
+    m_message = msg;
     add_msg_content(this, content_sizer, msg, false, is_marked_msg);
     finalize();
 }
@@ -479,14 +480,14 @@ DownloadDialog::DownloadDialog(wxWindow *parent, const wxString &msg, const wxSt
 {
     add_button(wxID_YES, true, _L("Download"));
     add_button(wxID_CANCEL, true, _L("Skip"));
-    
+    m_message = msg;
     finalize();
 }
 
 
 void DownloadDialog::SetExtendedMessage(const wxString &extendedMessage) 
 {
-    m_message += ": " +  msg + ": " + extendedMessage;
+    m_message += ": " + extendedMessage;
     add_msg_content(this, content_sizer, msg + "\n" + extendedMessage, false, false);
     Layout();
     Fit();

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -41,7 +41,7 @@ MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &he
     SetBackgroundColour(0xFFFFFF);
     SetFont(wxGetApp().normal_font());
     CenterOnParent();
-
+    
     auto *main_sizer = new wxBoxSizer(wxVERTICAL);
 	auto *topsizer = new wxBoxSizer(wxHORIZONTAL);
 	auto *rightsizer = new wxBoxSizer(wxVERTICAL);
@@ -71,6 +71,7 @@ MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &he
     apply_style(style);
 	SetSizerAndFit(main_sizer);
     wxGetApp().UpdateDlgDarkUI(this);
+    m_message = headline; //set here, and if if there's a further message in the derived class, it will be appended to this
 }
 
  MsgDialog::~MsgDialog()
@@ -336,7 +337,7 @@ ErrorDialog::ErrorDialog(wxWindow *parent, const wxString &msg, bool monospaced_
                         wxString::Format(_(L("%s has encountered an error")), SLIC3R_APP_FULL_NAME), wxOK)
 	, msg(msg)
 {
-    m_message = msg;
+    m_message += ": " +  msg;
     add_msg_content(this, content_sizer, msg, monospaced_font);
 
 	// Use a small bitmap with monospaced font, as the error text will not be wrapped.
@@ -356,7 +357,7 @@ WarningDialog::WarningDialog(wxWindow *parent,
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s warning"), SLIC3R_APP_FULL_NAME) : caption, 
                         wxString::Format(_L("%s has a warning")+":", SLIC3R_APP_FULL_NAME), style)
 {
-    m_message = message;
+    m_message += ": " +  message;
     add_msg_content(this, content_sizer, message);
     finalize();
 }
@@ -370,7 +371,7 @@ MessageDialog::MessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
-    m_message = message;
+    m_message += ": " +  message;
     add_msg_content(this, content_sizer, message);
     finalize();
     wxGetApp().UpdateDlgDarkUI(this);
@@ -385,7 +386,7 @@ RichMessageDialog::RichMessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
-    m_message = message;
+    m_message += ": " +  message;
     add_msg_content(this, content_sizer, message);
 
     m_checkBox = new wxCheckBox(this, wxID_ANY, m_checkBoxText);
@@ -415,7 +416,7 @@ InfoDialog::InfoDialog(wxWindow* parent, const wxString &title, const wxString& 
     : MsgDialog(parent, wxString::Format(_L("%s information"), SLIC3R_APP_FULL_NAME), title, style)
 	, msg(msg)
 {
-    m_message = msg;
+    m_message += ": " +  msg;
     add_msg_content(this, content_sizer, msg, false, is_marked_msg);
     finalize();
 }
@@ -485,7 +486,7 @@ DownloadDialog::DownloadDialog(wxWindow *parent, const wxString &msg, const wxSt
 
 void DownloadDialog::SetExtendedMessage(const wxString &extendedMessage) 
 {
-    m_message = msg + ": " + extendedMessage;
+    m_message += ": " +  msg + ": " + extendedMessage;
     add_msg_content(this, content_sizer, msg + "\n" + extendedMessage, false, false);
     Layout();
     Fit();

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -31,7 +31,7 @@
 namespace Slic3r {
 namespace GUI {
 
-MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style, wxBitmap bitmap)
+MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style, wxBitmap bitmap, const wxString& message)
 	: DPIDialog(parent ? parent : dynamic_cast<wxWindow*>(wxGetApp().mainframe), wxID_ANY, title, wxDefaultPosition, wxSize(360, -1),wxDEFAULT_DIALOG_STYLE)
 	, boldfont(wxGetApp().normal_font())
 	, content_sizer(new wxBoxSizer(wxVERTICAL))
@@ -393,16 +393,17 @@ RichMessageDialog::RichMessageDialog(wxWindow* parent,
     finalize();
 }
 
-int RichMessageDialog::ShowModal()
-{
-    if (m_checkBoxText.IsEmpty())
-        m_checkBox->Hide();
-    else
-        m_checkBox->SetLabelText(m_checkBoxText);
-    Layout();
-
-    return wxDialog::ShowModal();
-}
+// printago
+// int RichMessageDialog::ShowModal()
+// {
+//     if (m_checkBoxText.IsEmpty())
+//         m_checkBox->Hide();
+//     else
+//         m_checkBox->SetLabelText(m_checkBoxText);
+//     Layout();
+//
+//     return wxDialog::ShowModal();
+// }
 #endif
 
 // InfoDialog

--- a/src/slic3r/GUI/MsgDialog.cpp
+++ b/src/slic3r/GUI/MsgDialog.cpp
@@ -31,7 +31,7 @@
 namespace Slic3r {
 namespace GUI {
 
-MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style, wxBitmap bitmap, const wxString& message)
+MsgDialog::MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style, wxBitmap bitmap)
 	: DPIDialog(parent ? parent : dynamic_cast<wxWindow*>(wxGetApp().mainframe), wxID_ANY, title, wxDefaultPosition, wxSize(360, -1),wxDEFAULT_DIALOG_STYLE)
 	, boldfont(wxGetApp().normal_font())
 	, content_sizer(new wxBoxSizer(wxVERTICAL))
@@ -336,6 +336,7 @@ ErrorDialog::ErrorDialog(wxWindow *parent, const wxString &msg, bool monospaced_
                         wxString::Format(_(L("%s has encountered an error")), SLIC3R_APP_FULL_NAME), wxOK)
 	, msg(msg)
 {
+    m_message = msg;
     add_msg_content(this, content_sizer, msg, monospaced_font);
 
 	// Use a small bitmap with monospaced font, as the error text will not be wrapped.
@@ -355,6 +356,7 @@ WarningDialog::WarningDialog(wxWindow *parent,
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s warning"), SLIC3R_APP_FULL_NAME) : caption, 
                         wxString::Format(_L("%s has a warning")+":", SLIC3R_APP_FULL_NAME), style)
 {
+    m_message = message;
     add_msg_content(this, content_sizer, message);
     finalize();
 }
@@ -368,6 +370,7 @@ MessageDialog::MessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
+    m_message = message;
     add_msg_content(this, content_sizer, message);
     finalize();
     wxGetApp().UpdateDlgDarkUI(this);
@@ -382,6 +385,7 @@ RichMessageDialog::RichMessageDialog(wxWindow* parent,
     long style/* = wxOK*/)
     : MsgDialog(parent, caption.IsEmpty() ? wxString::Format(_L("%s info"), SLIC3R_APP_FULL_NAME) : caption, wxEmptyString, style)
 {
+    m_message = message;
     add_msg_content(this, content_sizer, message);
 
     m_checkBox = new wxCheckBox(this, wxID_ANY, m_checkBoxText);
@@ -411,6 +415,7 @@ InfoDialog::InfoDialog(wxWindow* parent, const wxString &title, const wxString& 
     : MsgDialog(parent, wxString::Format(_L("%s information"), SLIC3R_APP_FULL_NAME), title, style)
 	, msg(msg)
 {
+    m_message = msg;
     add_msg_content(this, content_sizer, msg, false, is_marked_msg);
     finalize();
 }
@@ -480,6 +485,7 @@ DownloadDialog::DownloadDialog(wxWindow *parent, const wxString &msg, const wxSt
 
 void DownloadDialog::SetExtendedMessage(const wxString &extendedMessage) 
 {
+    m_message = msg + ": " + extendedMessage;
     add_msg_content(this, content_sizer, msg + "\n" + extendedMessage, false, false);
     Layout();
     Fit();

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -85,7 +85,13 @@ struct MsgDialog : DPIDialog
     int ShowModal() override
     {
         SendPrintagoMessage();
-        return wxID_OK;
+
+        //send in this order, depending which buttons are present.
+        //we assume we want a no/cancel but an "OK" (or even "YES" may be expected from the caller).
+        return (m_style & wxCANCEL) ? wxID_CANCEL :
+               (m_style & wxNO)     ? wxID_NO :
+               (m_style & wxOK)     ? wxID_OK :
+               (m_style & wxYES)    ? wxID_YES : wxID_CANCEL;
     }
 
 protected:
@@ -118,10 +124,12 @@ protected:
     // Printago - keep a reference to the message here; this is used to send the message over a web socket, not the message in the dialog.
     // (The message in the dialog is not accessible from the outside of the parent class.)
     wxString m_message;
+    wxString m_headline;
+    long m_style; //lets us know what buttons are present for modal dialogs.
 
     void SendPrintagoMessage()
     {
-        wxGetApp().printago_director()->PostDialogMessage(this->GetTitle(), m_message);
+        wxGetApp().printago_director()->PostDialogMessage(this->GetTitle(), m_headline, m_message);
     }
 };
 
@@ -213,9 +221,6 @@ public:
 	RichMessageDialog &operator=(RichMessageDialog&&) = delete;
 	RichMessageDialog &operator=(const RichMessageDialog&) = delete;
 	virtual ~RichMessageDialog() = default;
-
-    //printago
-    // int  ShowModal() override;
 
 	void ShowCheckBox(const wxString& checkBoxText, bool checked = false)
 	{

--- a/src/slic3r/GUI/MsgDialog.hpp
+++ b/src/slic3r/GUI/MsgDialog.hpp
@@ -99,7 +99,7 @@ protected:
 		VERT_SPACING = 15,//TO
 	};
 
-	MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style = wxOK, wxBitmap bitmap = wxNullBitmap, const wxString& message = "");
+	MsgDialog(wxWindow *parent, const wxString &title, const wxString &headline, long style = wxOK, wxBitmap bitmap = wxNullBitmap);
 	// returns pointer to created button
 	Button* add_button(wxWindowID btn_id, bool set_focus = false, const wxString& label = wxString());
 	// returns pointer to found button or NULL
@@ -117,7 +117,7 @@ protected:
 
     // Printago - keep a reference to the message here; this is used to send the message over a web socket, not the message in the dialog.
     // (The message in the dialog is not accessible from the outside of the parent class.)
-    wxString m_message; 
+    wxString m_message;
 
     void SendPrintagoMessage()
     {

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -10221,40 +10221,43 @@ void Plater::reset_with_confirm()
 // BBS: save logic
 int GUI::Plater::close_with_confirm(std::function<bool(bool)> second_check)
 {
-    if (up_to_date(false, false)) {
-        if (second_check && !second_check(false)) return wxID_CANCEL;
-        model().set_backup_path("");
-        return wxID_NO;
-    }
-
-    MessageDialog dlg(static_cast<wxWindow*>(this), _L("The current project has unsaved changes, save it before continue?"),
-        wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Save"), wxYES_NO | wxCANCEL | wxYES_DEFAULT | wxCENTRE);
-    dlg.show_dsa_button(_L("Remember my choice."));
-    auto choise = wxGetApp().app_config->get("save_project_choise");
-    auto result = choise.empty() ? dlg.ShowModal() : choise == "yes" ? wxID_YES : wxID_NO;
-    if (result == wxID_CANCEL)
-        return result;
-    else {
-        if (dlg.get_checkbox_state())
-            wxGetApp().app_config->set("save_project_choise", result == wxID_YES ? "yes" : "no");
-        if (result == wxID_YES) {
-            result = save_project();
-            if (result == wxID_CANCEL) {
-                if (choise.empty())
-                    return result;
-                else
-                    result = wxID_NO;
-            }
-        }
-    }
-
-    if (second_check && !second_check(result == wxID_YES)) return wxID_CANCEL;
-
-    model().set_backup_path("");
-    up_to_date(true, false);
-    up_to_date(true, true);
-
-    return result;
+    //printago
+    return wxID_NO;
+    //
+    // if (up_to_date(false, false)) {
+    //     if (second_check && !second_check(false)) return wxID_CANCEL;
+    //     model().set_backup_path("");
+    //     return wxID_NO;
+    // }
+    //
+    // MessageDialog dlg(static_cast<wxWindow*>(this), _L("The current project has unsaved changes, save it before continue?"),
+    //     wxString(SLIC3R_APP_FULL_NAME) + " - " + _L("Save"), wxYES_NO | wxCANCEL | wxYES_DEFAULT | wxCENTRE);
+    // dlg.show_dsa_button(_L("Remember my choice."));
+    // auto choise = wxGetApp().app_config->get("save_project_choise");
+    // auto result = choise.empty() ? dlg.ShowModal() : choise == "yes" ? wxID_YES : wxID_NO;
+    // if (result == wxID_CANCEL)
+    //     return result;
+    // else {
+    //     if (dlg.get_checkbox_state())
+    //         wxGetApp().app_config->set("save_project_choise", result == wxID_YES ? "yes" : "no");
+    //     if (result == wxID_YES) {
+    //         result = save_project();
+    //         if (result == wxID_CANCEL) {
+    //             if (choise.empty())
+    //                 return result;
+    //             else
+    //                 result = wxID_NO;
+    //         }
+    //     }
+    // }
+    //
+    // if (second_check && !second_check(result == wxID_YES)) return wxID_CANCEL;
+    //
+    // model().set_backup_path("");
+    // up_to_date(true, false);
+    // up_to_date(true, true);
+    //
+    // return result;
 }
 
 //BBS: trigger a restore project event

--- a/src/slic3r/GUI/Plater.cpp
+++ b/src/slic3r/GUI/Plater.cpp
@@ -6942,9 +6942,11 @@ void Plater::priv::update_plugin_when_launch(wxCommandEvent &event)
     auto cache_folder = data_dir_path / "ota";
     std::string changelog_file = cache_folder.string() + "/network_plugins.json";
 
-    UpdatePluginDialog dlg(wxGetApp().mainframe);
-    dlg.update_info(changelog_file);
-    auto result = dlg.ShowModal();
+    // UpdatePluginDialog dlg(wxGetApp().mainframe);
+    // dlg.update_info(changelog_file);
+    // auto result = dlg.ShowModal();
+    //printago
+    auto result = wxID_OK;
 
     auto app_config = wxGetApp().app_config;
     if (!app_config) return;

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -687,7 +687,10 @@ SecondaryCheckDialog::SecondaryCheckDialog(wxWindow* parent, wxWindowID id, cons
     m_sizer_main->Add(m_sizer_right, 0, wxBOTTOM | wxEXPAND, FromDIP(5));
 
     Bind(wxEVT_CLOSE_WINDOW, [this](auto& e) {this->on_hide();});
-    Bind(wxEVT_ACTIVATE, [this](auto& e) { if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR); });
+    Bind(wxEVT_ACTIVATE, [this](auto& e) {
+        // if (!e.GetActive()) this->RequestUserAttention(wxUSER_ATTENTION_ERROR);
+         e.Skip();
+    });
 
     SetSizer(m_sizer_main);
     Layout();
@@ -953,46 +956,49 @@ ConfirmBeforeSendDialog::ConfirmBeforeSendDialog(wxWindow* parent, wxWindowID id
     wxGetApp().UpdateDlgDarkUI(this);
 }
 
-void ConfirmBeforeSendDialog::update_text(wxString text)
-{
-    wxBoxSizer* sizer_text_release_note = new wxBoxSizer(wxVERTICAL);
-    if (!m_staticText_release_note){
-        m_staticText_release_note = new Label(m_vebview_release_note, text, LB_AUTO_WRAP);
-        wxBoxSizer* top_blank_sizer = new wxBoxSizer(wxVERTICAL);
-        wxBoxSizer* bottom_blank_sizer = new wxBoxSizer(wxVERTICAL);
-        top_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        bottom_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-
-        sizer_text_release_note->Add(top_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        sizer_text_release_note->Add(m_staticText_release_note, 0, wxALIGN_CENTER, FromDIP(5));
-        sizer_text_release_note->Add(bottom_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        m_vebview_release_note->SetSizer(sizer_text_release_note);
-    }
-    m_staticText_release_note->SetMaxSize(wxSize(FromDIP(330), -1));
-    m_staticText_release_note->SetMinSize(wxSize(FromDIP(330), -1));
-    m_staticText_release_note->SetLabelText(text);
-    m_vebview_release_note->Layout();
-
-    auto text_size = m_staticText_release_note->GetBestSize();
-    if (text_size.y < FromDIP(360))
-        m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), text_size.y + FromDIP(25)));
-    else {
-        m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), FromDIP(360)));
-    }
-
-    Layout();
-    Fit();
-}
+// void ConfirmBeforeSendDialog::update_text(wxString text)
+// {
+//     wxBoxSizer* sizer_text_release_note = new wxBoxSizer(wxVERTICAL);
+//     if (!m_staticText_release_note){
+//         m_staticText_release_note = new Label(m_vebview_release_note, text, LB_AUTO_WRAP);
+//         wxBoxSizer* top_blank_sizer = new wxBoxSizer(wxVERTICAL);
+//         wxBoxSizer* bottom_blank_sizer = new wxBoxSizer(wxVERTICAL);
+//         top_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         bottom_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//
+//         sizer_text_release_note->Add(top_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         sizer_text_release_note->Add(m_staticText_release_note, 0, wxALIGN_CENTER, FromDIP(5));
+//         sizer_text_release_note->Add(bottom_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         m_vebview_release_note->SetSizer(sizer_text_release_note);
+//     }
+//     m_staticText_release_note->SetMaxSize(wxSize(FromDIP(330), -1));
+//     m_staticText_release_note->SetMinSize(wxSize(FromDIP(330), -1));
+//     m_staticText_release_note->SetLabelText(text);
+//     m_vebview_release_note->Layout();
+//
+//     auto text_size = m_staticText_release_note->GetBestSize();
+//     if (text_size.y < FromDIP(360))
+//         m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), text_size.y + FromDIP(25)));
+//     else {
+//         m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), FromDIP(360)));
+//     }
+//
+//     Layout();
+//     Fit();
+// }
 
 void ConfirmBeforeSendDialog::on_show()
 {
-    wxGetApp().UpdateDlgDarkUI(this);
-    // recover button color
-    wxMouseEvent evt_ok(wxEVT_LEFT_UP);
-    m_button_ok->GetEventHandler()->ProcessEvent(evt_ok);
-    wxMouseEvent evt_cancel(wxEVT_LEFT_UP);
-    m_button_cancel->GetEventHandler()->ProcessEvent(evt_cancel);
-    this->ShowModal();
+    // printago
+    wxGetApp().printago_director()->PostDialogMessage(this->GetTitle(), "ConfirmBeforeSendDialog", m_message);
+
+    // wxGetApp().UpdateDlgDarkUI(this);
+    // // recover button color
+    // wxMouseEvent evt_ok(wxEVT_LEFT_UP);
+    // m_button_ok->GetEventHandler()->ProcessEvent(evt_ok);
+    // wxMouseEvent evt_cancel(wxEVT_LEFT_UP);
+    // m_button_cancel->GetEventHandler()->ProcessEvent(evt_cancel);
+    // this->ShowModal();
 }
 
 void ConfirmBeforeSendDialog::on_hide()

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -707,49 +707,52 @@ void SecondaryCheckDialog::post_event(wxCommandEvent&& event)
     }
 }
 
-void SecondaryCheckDialog::update_text(wxString text)
-{
-    wxBoxSizer* sizer_text_release_note = new wxBoxSizer(wxVERTICAL);
-
-    if (!m_staticText_release_note) {
-        m_staticText_release_note = new Label(m_vebview_release_note, text, LB_AUTO_WRAP);
-        wxBoxSizer* top_blank_sizer = new wxBoxSizer(wxVERTICAL);
-        wxBoxSizer* bottom_blank_sizer = new wxBoxSizer(wxVERTICAL);
-        top_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        bottom_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-
-        sizer_text_release_note->Add(top_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        sizer_text_release_note->Add(m_staticText_release_note, 0, wxALIGN_CENTER, FromDIP(5));
-        sizer_text_release_note->Add(bottom_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
-        m_vebview_release_note->SetSizer(sizer_text_release_note);
-    }
-    m_staticText_release_note->SetMaxSize(wxSize(FromDIP(330), -1));
-    m_staticText_release_note->SetMinSize(wxSize(FromDIP(330), -1));
-    m_staticText_release_note->SetLabelText(text);
-    m_vebview_release_note->Layout();
-
-    auto text_size = m_staticText_release_note->GetBestSize();
-    if (text_size.y < FromDIP(360))
-        m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), text_size.y + FromDIP(25)));
-    else {
-        m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), FromDIP(360)));
-    }
-
-    Layout();
-    Fit();
-}
+// void SecondaryCheckDialog::update_text(wxString text)
+// {
+//     wxBoxSizer* sizer_text_release_note = new wxBoxSizer(wxVERTICAL);
+//
+//     if (!m_staticText_release_note) {
+//         m_staticText_release_note = new Label(m_vebview_release_note, text, LB_AUTO_WRAP);
+//         wxBoxSizer* top_blank_sizer = new wxBoxSizer(wxVERTICAL);
+//         wxBoxSizer* bottom_blank_sizer = new wxBoxSizer(wxVERTICAL);
+//         top_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         bottom_blank_sizer->Add(FromDIP(5), 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//
+//         sizer_text_release_note->Add(top_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         sizer_text_release_note->Add(m_staticText_release_note, 0, wxALIGN_CENTER, FromDIP(5));
+//         sizer_text_release_note->Add(bottom_blank_sizer, 0, wxALIGN_CENTER | wxALL, FromDIP(5));
+//         m_vebview_release_note->SetSizer(sizer_text_release_note);
+//     }
+//     m_staticText_release_note->SetMaxSize(wxSize(FromDIP(330), -1));
+//     m_staticText_release_note->SetMinSize(wxSize(FromDIP(330), -1));
+//     m_staticText_release_note->SetLabelText(text);
+//     m_vebview_release_note->Layout();
+//
+//     auto text_size = m_staticText_release_note->GetBestSize();
+//     if (text_size.y < FromDIP(360))
+//         m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), text_size.y + FromDIP(25)));
+//     else {
+//         m_vebview_release_note->SetMinSize(wxSize(FromDIP(360), FromDIP(360)));
+//     }
+//
+//     Layout();
+//     Fit();
+// }
 
 void SecondaryCheckDialog::on_show()
 {
-    wxGetApp().UpdateFrameDarkUI(this);
-    // recover button color
-    wxMouseEvent evt_ok(wxEVT_LEFT_UP);
-    m_button_ok->GetEventHandler()->ProcessEvent(evt_ok);
-    wxMouseEvent evt_cancel(wxEVT_LEFT_UP);
-    m_button_cancel->GetEventHandler()->ProcessEvent(evt_cancel);
-
-    this->Show();
-    this->Raise();
+    //printago
+     wxGetApp().printago_director()->PostDialogMessage(this->GetTitle(), "SecondaryCheckDialog", m_message);
+    
+    // wxGetApp().UpdateFrameDarkUI(this);
+    // // recover button color
+    // wxMouseEvent evt_ok(wxEVT_LEFT_UP);
+    // m_button_ok->GetEventHandler()->ProcessEvent(evt_ok);
+    // wxMouseEvent evt_cancel(wxEVT_LEFT_UP);
+    // m_button_cancel->GetEventHandler()->ProcessEvent(evt_cancel);
+    //
+    // this->Show();
+    // this->Raise();
 }
 
 void SecondaryCheckDialog::on_hide()

--- a/src/slic3r/GUI/ReleaseNote.cpp
+++ b/src/slic3r/GUI/ReleaseNote.cpp
@@ -650,9 +650,9 @@ SecondaryCheckDialog::SecondaryCheckDialog(wxWindow* parent, wxWindowID id, cons
         });
 
     if (btn_style == CONFIRM_AND_CANCEL) {
-        m_button_cancel->Show();
-        m_button_fn->Hide();
-        m_button_retry->Hide();
+        m_button_cancel->Show();  //cancel
+        m_button_fn->Hide();      //done
+        m_button_retry->Hide();   //retry
     } else if (btn_style == CONFIRM_AND_DONE) {
         m_button_cancel->Hide();
         m_button_fn->Show();
@@ -772,30 +772,30 @@ void SecondaryCheckDialog::update_title_style(wxString title, SecondaryCheckDial
 
     event_parent = parent;
 
-    if (style == CONFIRM_AND_CANCEL) {
+    if (style == CONFIRM_AND_CANCEL) {  //cancel this one.
         m_button_cancel->Show();
         m_button_fn->Hide();
         m_button_retry->Hide();
     }
-    else if (style == CONFIRM_AND_DONE) {
+    else if (style == CONFIRM_AND_DONE) {  //done this one.
         m_button_cancel->Hide();
         m_button_fn->Show();
         m_button_retry->Hide();
     }
-    else if (style == CONFIRM_AND_RETRY) {
-        m_button_retry->Show();
+    else if (style == CONFIRM_AND_RETRY) {  //confirm this one.
         m_button_cancel->Hide();
         m_button_fn->Hide();
-    }
-    else if (style == DONE_AND_RETRY) {
         m_button_retry->Show();
+    }
+    else if (style == DONE_AND_RETRY) {   //done this one.
+        m_button_cancel->Hide();
         m_button_fn->Show();
-        m_button_cancel->Hide();
+        m_button_retry->Show();
     }
-    else {
-        m_button_retry->Hide();
+    else {                                 //ok this one.
         m_button_cancel->Hide();
         m_button_fn->Hide();
+        m_button_retry->Hide();        
     }
 
 

--- a/src/slic3r/GUI/ReleaseNote.hpp
+++ b/src/slic3r/GUI/ReleaseNote.hpp
@@ -110,6 +110,8 @@ class SecondaryCheckDialog : public DPIFrame
 {
 private:
     wxWindow* event_parent { nullptr };
+    wxString  m_message;
+
 public:
     enum ButtonStyle {
         ONLY_CONFIRM        = 0,
@@ -129,7 +131,7 @@ public:
         long            style = wxCLOSE_BOX | wxCAPTION,
         bool not_show_again_check = false
     );
-    void update_text(wxString text);
+    void update_text(wxString text) { m_message = text; };
     void on_show();
     void on_hide();
     void update_btn_label(wxString ok_btn_text, wxString cancel_btn_text);

--- a/src/slic3r/GUI/ReleaseNote.hpp
+++ b/src/slic3r/GUI/ReleaseNote.hpp
@@ -160,6 +160,9 @@ public:
 
 class ConfirmBeforeSendDialog : public DPIDialog
 {
+private:
+    wxString m_message;
+
 public:
     enum ButtonStyle {
         ONLY_CONFIRM = 0,
@@ -176,7 +179,7 @@ public:
         long            style = wxCLOSE_BOX | wxCAPTION,
         bool not_show_again_check = false
     );
-    void update_text(wxString text);
+    void     update_text(wxString text) { m_message = text; };
     void on_show();
     void on_hide();
     void update_btn_label(wxString ok_btn_text, wxString cancel_btn_text);

--- a/src/slic3r/GUI/UnsavedChangesDialog.cpp
+++ b/src/slic3r/GUI/UnsavedChangesDialog.cpp
@@ -821,18 +821,21 @@ UnsavedChangesDialog::UnsavedChangesDialog(Preset::Type type, PresetCollection *
 
 inline int UnsavedChangesDialog::ShowModal()
 {
-    auto choise_key = "save_preset_choise"; 
-    auto choise     = wxGetApp().app_config->get(choise_key);
-    long result = 0;
-    if ((m_buttons & REMEMBER_CHOISE) && !choise.empty() && wxString(choise).ToLong(&result) && (1 << result) & (m_buttons | DONT_SAVE)) {
-        m_exit_action = Action(result);
-        return 0;
-    }
-    int r = wxDialog::ShowModal();
-    if (r != wxID_CANCEL && dynamic_cast<::CheckBox*>(FindWindowById(wxID_APPLY))->GetValue()) {
-        wxGetApp().app_config->set(choise_key, std::to_string(int(m_exit_action)));
-    }
-    return r;
+    //printago
+    m_exit_action = Action::Discard;
+    return 0;
+    // auto choise_key = "save_preset_choise"; 
+    // auto choise     = wxGetApp().app_config->get(choise_key);
+    // long result = 0;
+    // if ((m_buttons & REMEMBER_CHOISE) && !choise.empty() && wxString(choise).ToLong(&result) && (1 << result) & (m_buttons | DONT_SAVE)) {
+    //     m_exit_action = Action(result);
+    //     return 0;
+    // }
+    // int r = wxDialog::ShowModal();
+    // if (r != wxID_CANCEL && dynamic_cast<::CheckBox*>(FindWindowById(wxID_APPLY))->GetValue()) {
+    //     wxGetApp().app_config->set(choise_key, std::to_string(int(m_exit_action)));
+    // }
+    // return r;
 }
 
 void UnsavedChangesDialog::build(Preset::Type type, PresetCollection *dependent_presets, const std::string &new_selected_preset, const wxString &header)

--- a/src/slic3r/GUI/UpgradePanel.cpp
+++ b/src/slic3r/GUI/UpgradePanel.cpp
@@ -274,7 +274,7 @@ MachineInfoPanel::MachineInfoPanel(wxWindow* parent, wxWindowID id, const wxPoin
         upgrade_firmware_internal();
         });
 
-    m_staticText_release_note->Bind(wxEVT_LEFT_DOWN, &MachineInfoPanel::on_show_release_note, this);
+    // m_staticText_release_note->Bind(wxEVT_LEFT_DOWN, &MachineInfoPanel::on_show_release_note, this);
     m_button_upgrade_firmware->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(MachineInfoPanel::on_upgrade_firmware), NULL, this);
     wxGetApp().UpdateDarkUIWin(this);
 }

--- a/src/slic3r/Utils/PrintagoServer.cpp
+++ b/src/slic3r/Utils/PrintagoServer.cpp
@@ -201,7 +201,16 @@ void PrintagoDirector::PostJobUpdateMessage()
     resp->SetPrinterId(PBJob::printerId);
     resp->SetCommand("job_update");
     AddCurrentProcessJsonTo(responseData);
-    resp->SetData(responseData);
+
+    // public method; check authorization before dumping the message to the socket.
+    if (server->get_session()->get_authorized()) {
+        resp->SetData(responseData);
+    } else {
+        json noauth;
+        noauth["authorized"] = false;
+        noauth["error"]      = "Unauthorized";
+        resp->SetData(noauth);
+    }
 
     _PostResponse(*resp);
 }
@@ -246,9 +255,13 @@ void PrintagoDirector::PostStatusMessage(const wxString& printer_id, const json&
 
     _PostResponse(*resp);
 }
-
+//if it's the special ones and we're blocking then send a PrintagoError, and unblock the UI.
 void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxString& dialogHeadline, const wxString& dialogMessage)
 {
+    if (!server || !server->get_session()) {
+               return;
+    }
+
     json responseData;
     responseData["dialog_type"]    = dialogType.ToStdString();
     responseData["dialog_headline"] = dialogHeadline.ToStdString();
@@ -258,7 +271,22 @@ void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxStr
     resp->SetMessageType("gui_message");
     resp->SetPrinterId(PBJob::printerId);
     resp->SetData(responseData);
-    //try 
+
+    //public method; check authorization before dumping the message to the socket.
+    if (server->get_session()->get_authorized()) {
+        resp->SetData(responseData);
+        if (!dialogHeadline.compare("ConfirmBeforeSendDialog") || !dialogHeadline.compare("SecondaryCheckDialog")) {
+            wxGetApp().CallAfter([=] {
+                wxGetApp().printago_director()->PostErrorMessage("", "Orca Dialog Error", "", dialogMessage, true);
+            });
+        }
+    } else {
+        json noauth;
+        noauth["authorized"] = false;
+        noauth["error"]      = "Unauthorized";
+        resp->SetData(noauth);
+    }
+
     _PostResponse(*resp);
 }
 

--- a/src/slic3r/Utils/PrintagoServer.cpp
+++ b/src/slic3r/Utils/PrintagoServer.cpp
@@ -247,10 +247,11 @@ void PrintagoDirector::PostStatusMessage(const wxString& printer_id, const json&
     _PostResponse(*resp);
 }
 
-void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxString& dialogMessage)
+void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxString& dialogHeadline, const wxString& dialogMessage)
 {
     json responseData;
     responseData["dialog_type"]    = dialogType.ToStdString();
+    responseData["dialog_headline"] = dialogHeadline.ToStdString();
     responseData["dialog_message"] = dialogMessage.ToStdString();
 
     auto resp = std::make_unique<PrintagoResponse>();

--- a/src/slic3r/Utils/PrintagoServer.cpp
+++ b/src/slic3r/Utils/PrintagoServer.cpp
@@ -247,6 +247,20 @@ void PrintagoDirector::PostStatusMessage(const wxString& printer_id, const json&
     _PostResponse(*resp);
 }
 
+void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxString& dialogMessage)
+{
+    json responseData;
+    responseData["dialog_type"]    = dialogType.ToStdString();
+    responseData["dialog_message"] = dialogMessage.ToStdString();
+
+    auto resp = std::make_unique<PrintagoResponse>();
+    resp->SetMessageType("gui_message");
+    resp->SetPrinterId(PBJob::printerId);
+    resp->SetData(responseData);
+    //try 
+    _PostResponse(*resp);
+}
+
 void PrintagoDirector::_PostResponse(const PrintagoResponse& response) const
 {
     wxDateTime now = wxDateTime::Now();

--- a/src/slic3r/Utils/PrintagoServer.cpp
+++ b/src/slic3r/Utils/PrintagoServer.cpp
@@ -275,7 +275,7 @@ void PrintagoDirector::PostDialogMessage(const wxString& dialogType, const wxStr
     //public method; check authorization before dumping the message to the socket.
     if (server->get_session()->get_authorized()) {
         resp->SetData(responseData);
-        if (!dialogHeadline.compare("ConfirmBeforeSendDialog") || !dialogHeadline.compare("SecondaryCheckDialog")) {
+        if (!dialogHeadline.compare("ConfirmBeforeSendDialog") || !dialogHeadline.compare("SecondaryCheckDialog") || !dialogHeadline.compare("ShowIPAddress")) {
             wxGetApp().CallAfter([=] {
                 wxGetApp().printago_director()->PostErrorMessage("", "Orca Dialog Error", "", dialogMessage, true);
             });

--- a/src/slic3r/Utils/PrintagoServer.hpp
+++ b/src/slic3r/Utils/PrintagoServer.hpp
@@ -165,6 +165,7 @@ public:
     void OnPrintJobSent(wxString printerId, bool success);
 
     void PostJobUpdateMessage();
+    void PostDialogMessage(const wxString& dialogType, const wxString& dialogMessage);
 
     void ResetMachineDialog()
     {
@@ -185,10 +186,7 @@ private:
 
     void PostStatusMessage(const wxString& printer_id, const json& statusData, const json& command = {});
     void PostResponseMessage(const wxString& printer_id, const json& responseData, const json& command = {});
-    void PostSuccessMessage(const wxString& printer_id,
-                            const wxString& localCommand,
-                            const json&     command            = {},
-                            const wxString& localCommandDetail = "");
+    void PostSuccessMessage(const wxString& printer_id, const wxString& localCommand, const json& command = {}, const wxString& localCommandDetail = "");
     void PostErrorMessage(const wxString& printer_id, const wxString& localCommand, const json& command = {}, const wxString& errorDetail = "", const bool shouldUnblock = false);
 
     void _PostResponse(const PrintagoResponse& response) const;

--- a/src/slic3r/Utils/PrintagoServer.hpp
+++ b/src/slic3r/Utils/PrintagoServer.hpp
@@ -165,7 +165,7 @@ public:
     void OnPrintJobSent(wxString printerId, bool success);
 
     void PostJobUpdateMessage();
-    void PostDialogMessage(const wxString& dialogType, const wxString& dialogMessage);
+    void PostDialogMessage(const wxString& dialogType, const wxString& dialogHeadline, const wxString& dialogMessage);
 
     void ResetMachineDialog()
     {


### PR DESCRIPTION
9 classes derived from the MsgDialog class.  These messages are now, sent to the printago websocket.  The dialogs are not shown.
For instances where ShowModal() was used to open the dialog, I return the most falsy one.  The buttons are dynamic, but from a fixed set.  We send back to caller whatever is availabe in the dialog, in this order:  ["Cancel", "No", "OK", "Yes"].
These message are more like notifications.  They are feedback more than they are anything for the user to action.

Separately, there are the classes that derive from the parent class of MsgDialog.  Most we can ignore:

InputIpAddressDialog - sending to printer error, cancels blocking job 
UpdateVersionDialog - lambda that creates it was previously commented.
SecondaryCheckDialog - "Are you sure" messages, cancels blocking job
ConfirmBeforeSendDialog - slicing error messages, cancels blocking job.
ReleaseNoteDialog - called in one place, commented out.
UpdatePluginDialog - called once at startup; commented out.
