### PR TITLE
status/sync_profiles command complete.

### DIFF
--- a/src/slic3r/GUI/GUI_App.cpp
+++ b/src/slic3r/GUI/GUI_App.cpp
@@ -4719,9 +4719,9 @@ void GUI_App::sync_preset(Preset* preset)
     }
 }
 
-void GUI_App::start_sync_user_preset(bool with_progress_dlg)
+void GUI_App::start_sync_user_preset(bool with_progress_dlg, bool from_printago)
 {
-    if (app_config->get("stealth_mode") == "true")
+    if (!from_printago && app_config->get("stealth_mode") == "true")
         return;
 
     if (!m_agent || !m_agent->is_user_login()) return;
@@ -4757,7 +4757,10 @@ void GUI_App::start_sync_user_preset(bool with_progress_dlg)
     else {
         finishFn = [this, userid = m_agent->get_user_id(), t = std::weak_ptr<int>(m_user_sync_token)](bool ok) {
             CallAfter([=] {
-                if (ok && m_agent && t.lock() == m_user_sync_token && userid == m_agent->get_user_id()) reload_settings();
+                if (ok && m_agent && t.lock() == m_user_sync_token && userid == m_agent->get_user_id()) {
+                    reload_settings();
+                    wxGetApp().printago_director()->RefreshUserCloudProfilesComplete();
+                }
             });
         };
     }

--- a/src/slic3r/GUI/GUI_App.hpp
+++ b/src/slic3r/GUI/GUI_App.hpp
@@ -464,7 +464,7 @@ private:
     void            reload_settings();
     void            remove_user_presets();
     void            sync_preset(Preset* preset);
-    void            start_sync_user_preset(bool with_progress_dlg = false);
+    void            start_sync_user_preset(bool with_progress_dlg = false, bool from_printago = false);
     void            stop_sync_user_preset();
     void            start_http_server();
     void            stop_http_server();

--- a/src/slic3r/Utils/PrintagoServer.hpp
+++ b/src/slic3r/Utils/PrintagoServer.hpp
@@ -174,6 +174,7 @@ public:
     }
 
     std::shared_ptr<PrintagoServer> GetServer() { return server; }
+    void                            RefreshUserCloudProfilesComplete();
 
 private:
     std::shared_ptr<net::io_context> _io_context;
@@ -198,6 +199,8 @@ private:
 
     bool ValidatePrintagoCommand(const PrintagoCommand& cmd);
     bool ProcessPrintagoCommand(const PrintagoCommand& command);
+    bool RefreshUserCloudProfilesStart();
+    
 
     json GetAllStatus();
     void AddCurrentProcessJsonTo(json& statusObject);


### PR DESCRIPTION
Impl command: status/sync_profiles.  If logged in to BBL, fetches profiles into Orca.  Async replies:
{
  "client_type": "bambu",
  "command": {
    "action": "sync_profiles",
    "command": "status"
  },
  "data": {
    "local_command": "sync_profiles",
    "local_command_detail": "syncing profiles: async start",
    "success": true
  },
  "printer_id": "matt@printago.io",
  "timestamp": "2024-02-26T21:43:59Z",
  "type": "success"
}

{
  "client_type": "bambu",
  "command": "sync_profiles",
  "data": {
    "local_command": "sync_profiles",
    "local_command_detail": "syncing profiles: complete",
    "success": true
  },
  "printer_id": "matt@printago.io",
  "timestamp": "2024-02-26T21:44:04Z",
  "type": "success"
}